### PR TITLE
chore: move some dev only dependencies to the devDependencies part

### DIFF
--- a/platform/client-admin/package.json
+++ b/platform/client-admin/package.json
@@ -7,17 +7,6 @@
     "@capacitor/core": "2.0.1",
     "@ionic/react": "5.0.7",
     "@ionic/react-router": "5.0.7",
-    "@testing-library/jest-dom": "5.3.0",
-    "@testing-library/react": "10.0.2",
-    "@testing-library/user-event": "10.0.1",
-    "@types/google-map-react": "^1.1.6",
-    "@types/jest": "25.1.4",
-    "@types/node": "12.12.34",
-    "@types/react": "16.9.29",
-    "@types/react-dom": "16.9.5",
-    "@types/react-router": "5.1.4",
-    "@types/react-router-dom": "5.1.3",
-    "@types/simpl-schema": "^0.2.6",
     "apollo-link-context": "1.0.19",
     "apollo-link-ws": "1.0.19",
     "google-map-react": "1.1.7",
@@ -32,10 +21,8 @@
     "react-offix-hooks": "0.15.0",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "react-scripts": "3.4.1",
-    "simpl-schema": "^1.5.7",
+    "simpl-schema": "1.5.7",
     "subscriptions-transport-ws": "0.9.16",
-    "typescript": "3.8.3",
     "uniforms": "v3.0.0-alpha.2",
     "uniforms-bridge-simple-schema-2": "v3.0.0-alpha.2",
     "uniforms-ionic": "0.0.9"
@@ -65,6 +52,17 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "5.3.0",
+    "@testing-library/react": "10.0.2",
+    "@testing-library/user-event": "10.0.1",
+    "@types/google-map-react": "1.1.6",
+    "@types/jest": "25.1.4",
+    "@types/node": "12.12.34",
+    "@types/react": "16.9.29",
+    "@types/react-dom": "16.9.5",
+    "@types/react-router": "5.1.4",
+    "@types/react-router-dom": "5.1.3",
+    "@types/simpl-schema": "0.2.6",
     "@capacitor/cli": "2.0.1",
     "@graphql-codegen/add": "1.13.1",
     "@graphql-codegen/typescript": "1.13.1",
@@ -72,7 +70,9 @@
     "@graphql-codegen/typescript-react-apollo": "1.13.1",
     "@test-graphql-cli/codegen": "4.0.1-beta.3",
     "@types/googlemaps": "3.38.0",
-    "graphql-cli": "4.0.1-beta.3"
+    "graphql-cli": "4.0.1-beta.3",
+    "react-scripts": "3.4.1",
+    "typescript": "3.8.3"
   },
   "description": "An Ionic project"
 }

--- a/platform/client/package.json
+++ b/platform/client/package.json
@@ -7,17 +7,6 @@
     "@capacitor/core": "2.0.1",
     "@ionic/react": "5.0.7",
     "@ionic/react-router": "5.0.7",
-    "@testing-library/jest-dom": "5.3.0",
-    "@testing-library/react": "10.0.2",
-    "@testing-library/user-event": "10.0.1",
-    "@types/google-map-react": "^1.1.6",
-    "@types/jest": "25.1.4",
-    "@types/node": "12.12.34",
-    "@types/react": "16.9.29",
-    "@types/react-dom": "16.9.5",
-    "@types/react-router": "5.1.4",
-    "@types/react-router-dom": "5.1.3",
-    "@types/simpl-schema": "^0.2.6",
     "apollo-link-context": "1.0.19",
     "apollo-link-ws": "1.0.19",
     "google-map-react": "1.1.7",
@@ -32,10 +21,8 @@
     "react-offix-hooks": "0.15.0",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
-    "react-scripts": "3.4.1",
-    "simpl-schema": "^1.5.7",
+    "simpl-schema": "1.5.7",
     "subscriptions-transport-ws": "0.9.16",
-    "typescript": "3.8.3",
     "uniforms": "v3.0.0-alpha.2",
     "uniforms-bridge-simple-schema-2": "v3.0.0-alpha.2",
     "uniforms-ionic": "0.0.9"
@@ -65,6 +52,17 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "5.3.0",
+    "@testing-library/react": "10.0.2",
+    "@testing-library/user-event": "10.0.1",
+    "@types/google-map-react": "^1.1.6",
+    "@types/jest": "25.1.4",
+    "@types/node": "12.12.34",
+    "@types/react": "16.9.29",
+    "@types/react-dom": "16.9.5",
+    "@types/react-router": "5.1.4",
+    "@types/react-router-dom": "5.1.3",
+    "@types/simpl-schema": "0.2.6",
     "@capacitor/cli": "2.0.1",
     "@graphql-codegen/add": "1.13.1",
     "@graphql-codegen/typescript": "1.13.1",
@@ -72,7 +70,9 @@
     "@graphql-codegen/typescript-react-apollo": "1.13.1",
     "@test-graphql-cli/codegen": "4.0.1-beta.3",
     "@types/googlemaps": "3.38.0",
-    "graphql-cli": "4.0.1-beta.3"
+    "graphql-cli": "4.0.1-beta.3",
+    "react-scripts": "3.4.1",
+    "typescript": "3.8.3"
   },
   "description": "An Ionic project"
 }

--- a/platform/server/package.json
+++ b/platform/server/package.json
@@ -26,7 +26,6 @@
     "@aerogear/graphql-mqtt-subscriptions": "1.1.3",
     "@graphback/runtime-mongo": "0.12.0",
     "@graphql-toolkit/file-loading": "0.9.12",
-    "@types/react": "16.9.29",
     "apollo-server-express": "2.11.0",
     "cors": "2.8.5",
     "dotenv": "8.2.0",
@@ -36,9 +35,9 @@
     "graphql-tag": "2.10.3",
     "keycloak-connect": "9.0.2",
     "keycloak-connect-graphql": "0.4.0",
-    "mongo-seeding": "^3.4.0",
+    "mongo-seeding": "3.4.0",
     "mongodb": "3.5.5",
-    "mongodb-backup": "^1.6.9",
-    "mongodb-restore": "^1.6.2"
+    "mongodb-backup": "1.6.9",
+    "mongodb-restore": "1.6.2"
   }
 }


### PR DESCRIPTION

### Description

These deps are used in dev only, so can safely be moved. There are couple other that I am missing
but this is a good start.


- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
