### PR TITLE
feat: distribution centres in a a map

### DIFF
--- a/platform/client-admin/src/components/Router.tsx
+++ b/platform/client-admin/src/components/Router.tsx
@@ -24,6 +24,8 @@ import { CreateProductPage } from '../pages/CreateProductPage';
 import { CreateRecipientPage } from '../pages/CreateRecipientPage';
 import { CreateVolunteerPage } from '../pages/CreateVolunteerPage';
 import { CreateVolunteerActionPage } from '../pages/CreateVolunteerAction';
+import { ViewDistributionCentrePage } from '../pages/ViewDistributionCentrePage';
+import { CreateDistributionCentrePage } from '../pages/CreateDistributionCentrePage';
 
 export const Router: React.FC = () => {
   return (
@@ -50,6 +52,8 @@ export const Router: React.FC = () => {
               <Route path="/manageRecipient/:id" component={ViewRecipientPage} exact />
               <Route path="/createRecipient" component={CreateRecipientPage} exact />
               <Route path="/distributionCentre" component={DistributionCentrePage} exact />
+              <Route path="/manageDistributionCentre/:id" component={ViewDistributionCentrePage} exact />
+              <Route path="/createDistributionCentre" component={CreateDistributionCentrePage} exact />
               <Route path="/profile" component={ProfilePage} exact />
               <Redirect to={{ pathname: "actions" }} />
             </Switch>

--- a/platform/client-admin/src/dataFacade.tsx
+++ b/platform/client-admin/src/dataFacade.tsx
@@ -31,7 +31,6 @@ export type Address = {
 
 /**
  * @model
- * @crud.update: false
  * @crud.delete: false
  */
 export type DistributionCentre = Address & {
@@ -42,8 +41,8 @@ export type DistributionCentre = Address & {
   address2?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
   postcode?: Maybe<Scalars['Int']>;
-  lat?: Maybe<Scalars['String']>;
-  long?: Maybe<Scalars['String']>;
+  lat?: Maybe<Scalars['Float']>;
+  long?: Maybe<Scalars['Float']>;
   stockInformation?: Maybe<Scalars['JSON']>;
   /** @oneToMany field: 'distributionCentre', key: 'distributionCentreId' */
   products?: Maybe<Array<Maybe<Product>>>;
@@ -59,8 +58,8 @@ export type DistributionCentreInput = {
   address2?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
   postcode?: Maybe<Scalars['Int']>;
-  lat?: Maybe<Scalars['String']>;
-  long?: Maybe<Scalars['String']>;
+  lat?: Maybe<Scalars['Float']>;
+  long?: Maybe<Scalars['Float']>;
   stockInformation?: Maybe<Scalars['JSON']>;
   version?: Maybe<Scalars['Int']>;
 };
@@ -69,6 +68,7 @@ export type DistributionCentreInput = {
 export type Mutation = {
    __typename?: 'Mutation';
   createDistributionCentre: DistributionCentre;
+  updateDistributionCentre: DistributionCentre;
   createProduct: Product;
   updateProduct: Product;
   createVolunteerActionProduct: VolunteerActionProduct;
@@ -83,6 +83,11 @@ export type Mutation = {
 
 
 export type MutationCreateDistributionCentreArgs = {
+  input?: Maybe<DistributionCentreInput>;
+};
+
+
+export type MutationUpdateDistributionCentreArgs = {
   input?: Maybe<DistributionCentreInput>;
 };
 
@@ -296,6 +301,7 @@ export type RecipientInput = {
 export type Subscription = {
    __typename?: 'Subscription';
   newDistributionCentre: DistributionCentre;
+  updatedDistributionCentre: DistributionCentre;
   newProduct: Product;
   updatedProduct: Product;
   newVolunteer: Volunteer;
@@ -309,6 +315,11 @@ export type Subscription = {
 
 
 export type SubscriptionNewDistributionCentreArgs = {
+  input?: Maybe<DistributionCentreInput>;
+};
+
+
+export type SubscriptionUpdatedDistributionCentreArgs = {
   input?: Maybe<DistributionCentreInput>;
 };
 
@@ -650,6 +661,19 @@ export type DeleteVolunteerActionMutation = (
   & { deleteVolunteerAction: (
     { __typename?: 'VolunteerAction' }
     & VolunteerActionFieldsFragment
+  ) }
+);
+
+export type UpdateDistributionCentreMutationVariables = {
+  input: DistributionCentreInput;
+};
+
+
+export type UpdateDistributionCentreMutation = (
+  { __typename?: 'Mutation' }
+  & { updateDistributionCentre: (
+    { __typename?: 'DistributionCentre' }
+    & DistributionCentreFieldsFragment
   ) }
 );
 
@@ -1390,6 +1414,38 @@ export function useDeleteVolunteerActionMutation(baseOptions?: ApolloReactHooks.
 export type DeleteVolunteerActionMutationHookResult = ReturnType<typeof useDeleteVolunteerActionMutation>;
 export type DeleteVolunteerActionMutationResult = ApolloReactCommon.MutationResult<DeleteVolunteerActionMutation>;
 export type DeleteVolunteerActionMutationOptions = ApolloReactCommon.BaseMutationOptions<DeleteVolunteerActionMutation, DeleteVolunteerActionMutationVariables>;
+export const UpdateDistributionCentreDocument = gql`
+    mutation updateDistributionCentre($input: DistributionCentreInput!) {
+  updateDistributionCentre(input: $input) {
+    ...DistributionCentreFields
+  }
+}
+    ${DistributionCentreFieldsFragmentDoc}`;
+export type UpdateDistributionCentreMutationFn = ApolloReactCommon.MutationFunction<UpdateDistributionCentreMutation, UpdateDistributionCentreMutationVariables>;
+
+/**
+ * __useUpdateDistributionCentreMutation__
+ *
+ * To run a mutation, you first call `useUpdateDistributionCentreMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateDistributionCentreMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateDistributionCentreMutation, { data, loading, error }] = useUpdateDistributionCentreMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateDistributionCentreMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<UpdateDistributionCentreMutation, UpdateDistributionCentreMutationVariables>) {
+        return ApolloReactHooks.useMutation<UpdateDistributionCentreMutation, UpdateDistributionCentreMutationVariables>(UpdateDistributionCentreDocument, baseOptions);
+      }
+export type UpdateDistributionCentreMutationHookResult = ReturnType<typeof useUpdateDistributionCentreMutation>;
+export type UpdateDistributionCentreMutationResult = ApolloReactCommon.MutationResult<UpdateDistributionCentreMutation>;
+export type UpdateDistributionCentreMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateDistributionCentreMutation, UpdateDistributionCentreMutationVariables>;
 export const UpdateProductDocument = gql`
     mutation updateProduct($input: ProductInput!) {
   updateProduct(input: $input) {

--- a/platform/client-admin/src/forms/createVolunteer.ts
+++ b/platform/client-admin/src/forms/createVolunteer.ts
@@ -43,7 +43,7 @@ const volunteerForm = new SimpleSchema({
         required: false,
         uniforms: {
             label: "Date Of Birth"
-        },
+        }
     },
     canDeliver: {
         type: Boolean,

--- a/platform/client-admin/src/forms/distributionCentre.ts
+++ b/platform/client-admin/src/forms/distributionCentre.ts
@@ -1,0 +1,49 @@
+import SimpleSchema2Bridge from 'uniforms-bridge-simple-schema-2';
+import SimpleSchema from 'simpl-schema';
+
+const distributionCentre = new SimpleSchema({
+    name: {
+        type: String,
+        max: 120
+    },
+    address1: {
+        type: String,
+        max: 400
+    },
+    address2: {
+        type: String,
+        max: 400
+    },
+    city: {
+        type: String,
+        required: false,
+        max: 100
+    },
+    postcode: {
+        type: Number,
+        required: false,
+    },
+    lat: {
+        type: Number,
+        required: false,
+        uniforms: {
+            label: "Latitude"
+        }
+    },
+    long: {
+        type: Number,
+        required: false,
+        uniforms: {
+            label: "Longitude"
+        }
+    },
+    stockInformation: {
+        type: String,
+        required: false,
+        uniforms: {
+            label: "Stock information in JSON format"
+        }
+    } 
+} as any);
+
+export default new SimpleSchema2Bridge(distributionCentre);

--- a/platform/client-admin/src/graphql/mutations/updateDistributionCentre.graphql
+++ b/platform/client-admin/src/graphql/mutations/updateDistributionCentre.graphql
@@ -1,0 +1,5 @@
+mutation updateDistributionCentre($input: DistributionCentreInput!) {
+  updateDistributionCentre(input: $input) {
+      ...DistributionCentreFields
+  }
+}

--- a/platform/client-admin/src/pages/CreateDistributionCentrePage.tsx
+++ b/platform/client-admin/src/pages/CreateDistributionCentrePage.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { Header } from '../components/Header';
+import { IUpdateMatchParams } from '../declarations';
+import { useCreateDistributionCentreMutation } from '../dataFacade';
+import { AutoForm } from 'uniforms-ionic';
+import distributionCentreForm from '../forms/distributionCentre';
+import { IonContent, IonList, IonCard, IonItemGroup, IonItemDivider } from '@ionic/react';
+import { useHistory } from 'react-router';
+import { useState } from 'react';
+
+export const CreateDistributionCentrePage: React.FC<RouteComponentProps<IUpdateMatchParams>> = ({ match }) => {
+  const history = useHistory();
+  const [createDistributionCentre] = useCreateDistributionCentreMutation()
+
+  const [model, setModel] = useState({
+    stockInformation: "{}",
+    lat: 0,
+    long: 0
+  });
+
+  if (navigator.geolocation) {
+    navigator.geolocation
+      .getCurrentPosition((location) => {
+        setModel({
+          lat: location.coords.latitude,
+          long: location.coords.longitude,
+          stockInformation: model.stockInformation
+        });
+
+        // TODO - get city and address using Google Map API and put on map
+      }, console.error);
+  }
+
+
+  return (
+    <>
+      <Header title="Manage Distribution Centre" match={match} />
+      <IonContent>
+        <IonList>
+          <IonCard>
+            <IonItemGroup>
+              <IonItemDivider color="light">
+                <h2>Distribution centre information</h2>
+              </IonItemDivider>
+              <AutoForm
+                placeholder
+                model={model}
+                schema={distributionCentreForm}
+                onSubmit={(model: any) => {
+                  createDistributionCentre({
+                    variables: {
+                      input: {
+                        lat: model.lat,
+                        city: model.city,
+                        long: model.long,
+                        name: model.name,
+                        address1: model.address1,
+                        address2: model.address2,
+                        postcode: model.postcode,
+                        stockInformation: JSON.parse(model.stockInformation),
+                      }
+                    }
+                  }).then(({ data }) => {
+                    history.push(`/manageDistributionCentre/${data?.createDistributionCentre.id}`);
+                  }).catch(console.error);
+                }}
+                showInlineError
+                submitField={undefined}
+              >
+              </AutoForm>
+            </IonItemGroup>
+          </IonCard>
+        </IonList>
+      </IonContent>
+
+
+    </>
+  );
+
+}

--- a/platform/client-admin/src/pages/DistributionCentrePage.tsx
+++ b/platform/client-admin/src/pages/DistributionCentrePage.tsx
@@ -1,7 +1,84 @@
 import React from 'react';
+import { useFindAllDistributionCentresQuery } from '../dataFacade';
+import { IonLoading, IonPage, IonContent, IonFooter, IonButton, IonIcon } from '@ionic/react';
+import { Header, Empty } from '../components';
+import { RouteComponentProps, useHistory } from 'react-router';
+import { Marker } from 'google-maps-react';
+import { Map } from '../components/Map';
+import { Link } from 'react-router-dom';
+import { open } from 'ionicons/icons';
 
-export const DistributionCentrePage: React.FC = () => {
+export const DistributionCentrePage: React.FC<RouteComponentProps> = ({ match }) => {
+  const history = useHistory();
+  let { data, loading, error } = useFindAllDistributionCentresQuery();
 
-  return <>Under construction</>
+  if (error) {
+    console.log(error);
+  }
 
+  if (loading) return <IonLoading
+    isOpen={loading}
+    message={'Loading...'}
+  />;
+
+  const distributionCentres = data?.findAllDistributionCentres || [];
+
+  let mapContent = <Empty />;
+  const size = distributionCentres.length;
+
+  if (size > 0) {
+    const totalLatLong = {
+      lat: 0, lng: 0
+    };
+
+    let distributionMarkers = distributionCentres
+      .map((distributionCentre, index) => {
+        const lat = distributionCentre?.lat!;
+        const lng = distributionCentre?.long!;
+
+        totalLatLong.lat += lat;
+        totalLatLong.lng += lng;
+
+        const title = `${distributionCentre?.address1} ${distributionCentre?.address2} ${distributionCentre?.city}`;
+
+        return <Marker
+          key={index}
+          title={title}
+          label={distributionCentre?.name!}
+          onClick={() => history.push(`/manageDistributionCentre/${distributionCentre?.id}`)}
+          position={{
+            lat,
+            lng
+          }} />
+      });
+
+    mapContent = <Map
+      zoom={2}
+      center={{
+        lat: totalLatLong.lat / size,
+        lng: totalLatLong.lng / size
+      }}>
+      {distributionMarkers}
+    </Map>
+  }
+
+  return (
+    <IonPage>
+      <Header title="List of Distribution" match={match} />
+      <IonContent className="ion-padding" >
+      <Link to={'createDistributionCentre'}>
+          <IonButton item-start color='primary' fill="outline">
+            <IonIcon icon={open} />
+              Create Distribution Centre
+          </IonButton>
+        </Link>
+        {mapContent}
+      </IonContent>
+      <IonFooter>
+        <div>
+          OpenVolunteer Platform
+        </div>
+      </IonFooter>
+    </IonPage >
+  );
 };

--- a/platform/client-admin/src/pages/ViewActionPage.tsx
+++ b/platform/client-admin/src/pages/ViewActionPage.tsx
@@ -41,15 +41,15 @@ export const ViewActionPage: React.FC<RouteComponentProps<IUpdateMatchParams>> =
     const distributionCentre = model.distributionCentre;
     const title = `${distributionCentre.address1} ${distributionCentre.address2} ${distributionCentre.city}`;
     mapContent = <Map center={{
-      lat: parseInt(distributionCentre.lat!),
-      lng: parseInt(distributionCentre.long!)
+      lat: distributionCentre.lat!,
+      lng: distributionCentre.long!
     }}>
       <Marker
         label={distributionCentre.name!}
         title={title}
         position={{
-          lat: parseInt(distributionCentre.lat!),
-          lng: parseInt(distributionCentre.long!)
+          lat: distributionCentre.lat!,
+          lng: distributionCentre.long!
         }} />
     </Map>
   }

--- a/platform/client-admin/src/pages/ViewDistributionCentrePage.tsx
+++ b/platform/client-admin/src/pages/ViewDistributionCentrePage.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { Header } from '../components/Header';
+import { IUpdateMatchParams } from '../declarations';
+import { useFindDistributionCentresQuery, useUpdateDistributionCentreMutation } from '../dataFacade';
+import { AutoForm } from 'uniforms-ionic';
+import distributionCentreForm from '../forms/distributionCentre';
+import { IonLoading, IonContent, IonList, IonCard, IonItemGroup, IonItemDivider } from '@ionic/react';
+import { Marker } from 'google-maps-react';
+import { Map } from '../components/Map';
+
+export const ViewDistributionCentrePage: React.FC<RouteComponentProps<IUpdateMatchParams>> = ({ match }) => {
+  const { data, loading, error } = useFindDistributionCentresQuery({ variables: { fields: { id: match.params.id }, limit: 1 } });
+  const [updateDistributionCentre] = useUpdateDistributionCentreMutation()
+  if (error) {
+    console.log(error);
+  }
+
+  const distributionCentre = data?.findDistributionCentres[0];
+
+  if (!distributionCentre) {
+    return <div>Cannot fetch element with provided id</div>
+  }
+
+  if (loading) return <IonLoading isOpen={loading} message={'Loading...'} />;
+
+  const title = `${distributionCentre.address1} ${distributionCentre.address2} ${distributionCentre.city}`;
+  let mapContent = <Map
+    zoom={14}
+    center={{
+      lat: distributionCentre.lat!,
+      lng: distributionCentre.long!
+    }}>
+    <Marker
+      label={distributionCentre.name!}
+      title={title}
+      position={{
+        lat: distributionCentre.lat!,
+        lng: distributionCentre.long!
+      }} />
+  </Map>
+
+  const model = {
+    ...distributionCentre,
+    stockInformation: JSON.stringify(distributionCentre.stockInformation, null, '\t')
+  };
+
+  return (
+    <>
+      <Header title="Manage Distribution Centre" match={match} />
+      <IonContent>
+        <IonList>
+          <IonCard>
+            <IonItemGroup>
+              <IonItemDivider color="light">
+                <h2>Distribution centre information</h2>
+              </IonItemDivider>
+              <AutoForm
+                placeholder
+                model={model}
+                schema={distributionCentreForm}
+                onSubmit={(model: any) => {
+                  updateDistributionCentre({
+                    variables: {
+                      input: {
+                        id: model.id,
+                        city: model.city,
+                        lat: model.lat,
+                        long: model.long,
+                        name: model.name,
+                        address1: model.address1,
+                        address2: model.address2,
+                        postcode: model.postcode,
+                        stockInformation: JSON.parse(model.stockInformation),
+                      }
+                    }
+                  }).then(() => {
+                    // TODO dialog
+                  }).catch(console.error);
+                }}
+                showInlineError
+                submitField={undefined}
+              >
+              </AutoForm>
+              {mapContent}
+            </IonItemGroup>
+          </IonCard>
+        </IonList>
+      </IonContent>
+
+
+    </>
+  );
+
+}

--- a/platform/client/src/dataFacade.tsx
+++ b/platform/client/src/dataFacade.tsx
@@ -31,7 +31,6 @@ export type Address = {
 
 /**
  * @model
- * @crud.update: false
  * @crud.delete: false
  */
 export type DistributionCentre = Address & {
@@ -42,8 +41,8 @@ export type DistributionCentre = Address & {
   address2?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
   postcode?: Maybe<Scalars['Int']>;
-  lat?: Maybe<Scalars['String']>;
-  long?: Maybe<Scalars['String']>;
+  lat?: Maybe<Scalars['Float']>;
+  long?: Maybe<Scalars['Float']>;
   stockInformation?: Maybe<Scalars['JSON']>;
   /** @oneToMany field: 'distributionCentre', key: 'distributionCentreId' */
   products?: Maybe<Array<Maybe<Product>>>;
@@ -59,8 +58,8 @@ export type DistributionCentreInput = {
   address2?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
   postcode?: Maybe<Scalars['Int']>;
-  lat?: Maybe<Scalars['String']>;
-  long?: Maybe<Scalars['String']>;
+  lat?: Maybe<Scalars['Float']>;
+  long?: Maybe<Scalars['Float']>;
   stockInformation?: Maybe<Scalars['JSON']>;
   version?: Maybe<Scalars['Int']>;
 };
@@ -69,6 +68,7 @@ export type DistributionCentreInput = {
 export type Mutation = {
    __typename?: 'Mutation';
   createDistributionCentre: DistributionCentre;
+  updateDistributionCentre: DistributionCentre;
   createProduct: Product;
   updateProduct: Product;
   createVolunteerActionProduct: VolunteerActionProduct;
@@ -83,6 +83,11 @@ export type Mutation = {
 
 
 export type MutationCreateDistributionCentreArgs = {
+  input?: Maybe<DistributionCentreInput>;
+};
+
+
+export type MutationUpdateDistributionCentreArgs = {
   input?: Maybe<DistributionCentreInput>;
 };
 
@@ -296,6 +301,7 @@ export type RecipientInput = {
 export type Subscription = {
    __typename?: 'Subscription';
   newDistributionCentre: DistributionCentre;
+  updatedDistributionCentre: DistributionCentre;
   newProduct: Product;
   updatedProduct: Product;
   newVolunteer: Volunteer;
@@ -309,6 +315,11 @@ export type Subscription = {
 
 
 export type SubscriptionNewDistributionCentreArgs = {
+  input?: Maybe<DistributionCentreInput>;
+};
+
+
+export type SubscriptionUpdatedDistributionCentreArgs = {
   input?: Maybe<DistributionCentreInput>;
 };
 

--- a/platform/client/src/pages/ViewActionPage.tsx
+++ b/platform/client/src/pages/ViewActionPage.tsx
@@ -24,7 +24,6 @@ export const ViewActionPage: React.FC<RouteComponentProps<IUpdateMatchParams>> =
 
   if (loading) return <IonLoading isOpen={loading} message={'Loading...'} />;
   const model = data.findVolunteerActions[0];
-  console.log(model)
 
   let mapContent = <Empty />;
   
@@ -32,15 +31,15 @@ export const ViewActionPage: React.FC<RouteComponentProps<IUpdateMatchParams>> =
     const distributionCentre = model.distributionCentre;
     const title = `${distributionCentre.address1} ${distributionCentre.address2} ${distributionCentre.city}`;
     mapContent = <Map center={{
-      lat: parseInt(distributionCentre.lat!),
-      lng: parseInt(distributionCentre.long!)
+      lat: distributionCentre.lat!,
+      lng: distributionCentre.long!
     }}>
       <Marker
         label={distributionCentre.name!}
         title={title}
         position={{
-          lat: parseInt(distributionCentre.lat!),
-          lng: parseInt(distributionCentre.long!)
+          lat: distributionCentre.lat!,
+          lng: distributionCentre.long!
         }} />
     </Map>
   }

--- a/platform/model/main.graphql
+++ b/platform/model/main.graphql
@@ -1,6 +1,5 @@
 """
 @model
-@crud.update: false
 @crud.delete: false
 """
 type DistributionCentre implements Address {
@@ -10,8 +9,8 @@ type DistributionCentre implements Address {
   address2: String
   city: String
   postcode: Int
-  lat: String
-  long: String
+  lat: Float
+  long: Float
   stockInformation: JSON,
   
   """

--- a/platform/server/src/resolvers/resolvers.ts
+++ b/platform/server/src/resolvers/resolvers.ts
@@ -145,6 +145,9 @@ export default {
     createDistributionCentre: (parent, args, context) => {
       return context.DistributionCentre.create(args.input, context)
     },
+    updateDistributionCentre: (parent, args, context) => {
+      return context.DistributionCentre.update(args.input, context)
+    },
     createProduct: (parent, args, context) => {
       return context.Product.create(args.input, context)
     },
@@ -181,6 +184,11 @@ export default {
     newDistributionCentre: {
       subscribe: (parent, args, context) => {
         return context.DistributionCentre.subscribeToCreate(args, context)
+      },
+    },
+    updatedDistributionCentre: {
+      subscribe: (parent, args, context) => {
+        return context.DistributionCentre.subscribeToUpdate(args, context)
       },
     },
     newProduct: {

--- a/platform/server/src/schema/schema.graphql
+++ b/platform/server/src/schema/schema.graphql
@@ -17,7 +17,6 @@ scalar DateTime
 
 """
 @model
-@crud.update: false
 @crud.delete: false
 """
 type DistributionCentre implements Address {
@@ -27,8 +26,8 @@ type DistributionCentre implements Address {
   address2: String
   city: String
   postcode: Int
-  lat: String
-  long: String
+  lat: Float
+  long: Float
   stockInformation: JSON
 
   """@oneToMany field: 'distributionCentre', key: 'distributionCentreId'"""
@@ -46,8 +45,8 @@ input DistributionCentreInput {
   address2: String
   city: String
   postcode: Int
-  lat: String
-  long: String
+  lat: Float
+  long: Float
   stockInformation: JSON
   version: Int
 }
@@ -56,6 +55,7 @@ scalar JSON
 
 type Mutation {
   createDistributionCentre(input: DistributionCentreInput): DistributionCentre!
+  updateDistributionCentre(input: DistributionCentreInput): DistributionCentre!
   createProduct(input: ProductInput): Product!
   updateProduct(input: ProductInput): Product!
   createVolunteerActionProduct(input: VolunteerActionProductInput): VolunteerActionProduct!
@@ -150,6 +150,7 @@ input RecipientInput {
 
 type Subscription {
   newDistributionCentre(input: DistributionCentreInput): DistributionCentre!
+  updatedDistributionCentre(input: DistributionCentreInput): DistributionCentre!
   newProduct(input: ProductInput): Product!
   updatedProduct(input: ProductInput): Product!
   newVolunteer(input: VolunteerInput): Volunteer!


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
<img width="843" alt="Screenshot 2020-05-20 at 13 02 01" src="https://user-images.githubusercontent.com/10106536/82439026-431f7e80-9a9a-11ea-956f-3bd833d8d46b.png">

We have that little nice view, opening as draft as I need to bring in in the detail view so that when you click on a distribution marker it'll land you to the distribution centre detail edit/ view. 